### PR TITLE
Fix recursive inclusion of files with cwd

### DIFF
--- a/tasks/debian_package.js
+++ b/tasks/debian_package.js
@@ -49,7 +49,7 @@ function preparePackageContents (makefile, files, follow_soft_links, quiet) {
                     destination = file.dest;
                 }
             }
-            var mkdirPath = destination.endsWith('/') ? destination.replace(/\/$/, '') : path.dirname(destination);
+            var mkdirPath = destination.endsWith('/') ? destination.replace(/\/+$/, '') : path.dirname(destination);
             return '\tmkdir -p "$(DESTDIR)' + mkdirPath + '" && cp -a ' + (follow_soft_links ? '' : '-P ') + '"' + process.cwd() + '/' + filepath + '" "$(DESTDIR)' + destination + '"\n';
         }).join('');
     });

--- a/tasks/debian_package.js
+++ b/tasks/debian_package.js
@@ -25,7 +25,7 @@ var _validateOptions = options._validate,
 
 function preparePackageContents (makefile, files, follow_soft_links, quiet) {
     _transformAndReplace([makefile], '\\$\\{file_list\\}', files, function (file) {
-        return [].concat.apply([], 
+        return [].concat.apply([],
             file.src.map(function (src) {
                 return glob.sync(path.join(file.cwd || '', src));
             })
@@ -41,7 +41,16 @@ function preparePackageContents (makefile, files, follow_soft_links, quiet) {
             if (!quiet) {
                 console.log('Adding \'' + filepath + '\' to \'' + file.dest + '\'');
             }
-            return '\tmkdir -p "$(DESTDIR)' + file.dest.substr(0, file.dest.lastIndexOf('/')) + '" && cp -a ' + (follow_soft_links ? "" : "-P ") + '"' + process.cwd() + '/' + filepath + '" "$(DESTDIR)' + file.dest + '"\n';
+            var destination = file.dest;
+            if (file.dest.endsWith('/')) {
+                if (file.cwd) {
+                    destination = path.join(file.dest, path.relative(file.cwd, filepath));
+                } else {
+                    destination = file.dest;
+                }
+            }
+            var mkdirPath = destination.endsWith('/') ? destination.replace(/\/$/, '') : path.dirname(destination);
+            return '\tmkdir -p "$(DESTDIR)' + mkdirPath + '" && cp -a ' + (follow_soft_links ? '' : '-P ') + '"' + process.cwd() + '/' + filepath + '" "$(DESTDIR)' + destination + '"\n';
         }).join('');
     });
 }


### PR DESCRIPTION
## Summary
- preserve relative paths when packaging files with a `cwd`
- keep previous behaviour when no `cwd` is provided

## Testing
- `npx grunt test`

------
https://chatgpt.com/codex/tasks/task_e_68775cf2f6488320abd75222e54bff07

## Summary by Sourcery

Adjust file packaging logic to preserve relative file paths when a cwd is provided and update mkdir and cp commands accordingly, retaining previous behavior when no cwd is specified

Enhancements:
- Preserve relative directory structure for files when a cwd is used
- Compute destination paths and mkdir targets dynamically based on cwd and file.dest
- Maintain existing packaging behavior when no cwd is provided